### PR TITLE
fixing bug where navbar search took you to the worng site

### DIFF
--- a/src/components/header/Navbar.tsx
+++ b/src/components/header/Navbar.tsx
@@ -28,7 +28,7 @@ const Navbar = () => {
 
         <NavigationMenu.Item>
           <NavigationMenu.Link
-            href="search"
+            href="/search"
             className="group flex select-none items-center justify-between gap-[2px] rounded-[4px] px-3 py-2 text-[15px] font-medium leading-none outline-none hover:underline"
           >
             Search


### PR DESCRIPTION
since the search link in the navbar was missing a / in front. 
the link did not always take you to the search page, depending on which site you were on when clicking.